### PR TITLE
Removing the master and slave jargon

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps(object):
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -51,7 +51,7 @@ class Apps(object):
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -212,7 +212,7 @@ TEMPLATES = []
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -63,7 +63,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name, type FROM sqlite_master
+            SELECT name, type FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
@@ -107,7 +107,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         try:
             results = cursor.fetchone()[0].strip()
         except TypeError:
@@ -135,7 +135,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else:
                 field_name = field_desc.split()[0].strip('"')
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -161,7 +161,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -206,7 +206,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         row = cursor.fetchone()
         if row is None:
             raise ValueError("Table %s does not exist" % table_name)

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -455,7 +455,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -68,7 +68,7 @@ class RemoteTestResult(object):
     Record information about which tests have succeeded and which have failed.
 
     The sole purpose of this class is to record events in the child processes
-    so they can be replayed in the master process. As a consequence it doesn't
+    so they can be replayed in the main process. As a consequence it doesn't
     inherit unittest.TestResult and doesn't attempt to implement all its API.
 
     The implementation matches the unpythonic coding style of unittest2.

--- a/freenasUI/choices.py
+++ b/freenasUI/choices.py
@@ -664,7 +664,7 @@ SERIAL_SPEED = (
 
 SED_USER = (
     ('user', _('User')),
-    ('master', _('Master')),
+    ('main', _('Main')),
 )
 
 

--- a/freenasUI/failover/migrations/0001_initial.py
+++ b/freenasUI/failover/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('disabled', models.BooleanField(default=False)),
-                ('master', models.BooleanField(default=False)),
+                ('main', models.BooleanField(default=False)),
                 ('timeout', models.IntegerField(default=0)),
             ],
             options={

--- a/freenasUI/services/migrations/0001_initial.py
+++ b/freenasUI/services/migrations/0001_initial.py
@@ -70,7 +70,7 @@ class Migration(migrations.Migration):
                 ('cifs_srv_unixcharset', models.CharField(choices=choices.UNIXCHARSET_CHOICES, default='UTF-8', max_length=120, verbose_name='UNIX charset')),
                 ('cifs_srv_loglevel', models.CharField(choices=choices.LOGLEVEL_CHOICES, default='0', max_length=120, verbose_name='Log level')),
                 ('cifs_srv_syslog', models.BooleanField(default=False, verbose_name='Use syslog only')),
-                ('cifs_srv_localmaster', models.BooleanField(default=False, verbose_name='Local Master')),
+                ('cifs_srv_localmain', models.BooleanField(default=False, verbose_name='Local Main')),
                 ('cifs_srv_domain_logons', models.BooleanField(default=False, verbose_name='Domain logons')),
                 ('cifs_srv_timeserver', models.BooleanField(default=False, verbose_name='Time Server for Domain')),
                 ('cifs_srv_guest', freenasUI.freeadmin.models.fields.UserField(default='nobody', help_text="Use this option to override the username ('nobody' by default) which will be used for access to services which are specified as guest. Whatever privileges this user has will be available to any client connecting to the guest service. This user must exist in the password file, but does not require a valid login. The user root cannot be used as guest account.", max_length=120, verbose_name='Guest account')),
@@ -516,7 +516,7 @@ class Migration(migrations.Migration):
             name='UPS',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('ups_mode', models.CharField(choices=[('master', 'Master'), ('slave', 'Slave')], default='master', max_length=6, verbose_name='UPS Mode')),
+                ('ups_mode', models.CharField(choices=[('main', 'Main'), ('subordinate', 'Subordinate')], default='main', max_length=6, verbose_name='UPS Mode')),
                 ('ups_identifier', models.CharField(default='ups', help_text='This name is used to uniquely identify your UPS on this system.', max_length=120, verbose_name='Identifier')),
                 ('ups_remotehost', models.CharField(blank=True, max_length=50, verbose_name='Remote Host')),
                 ('ups_remoteport', models.IntegerField(blank=True, default=3493, verbose_name='Remote Port')),

--- a/freenasUI/services/migrations/0021_add_ups_hostsync_field.py
+++ b/freenasUI/services/migrations/0021_add_ups_hostsync_field.py
@@ -14,8 +14,8 @@ class Migration(migrations.Migration):
             field=models.IntegerField(
                 default=15,
                 verbose_name='Host Sync',
-                help_text='Upsmon will wait up to this many seconds in master '
-                          'mode for the slaves to disconnect during a shutdown situation'
+                help_text='Upsmon will wait up to this many seconds in main '
+                          'mode for the subordinates to disconnect during a shutdown situation'
             ),
         )
     ]

--- a/freenasUI/system/migrations/0011_auto_20180219_1615.py
+++ b/freenasUI/system/migrations/0011_auto_20180219_1615.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
         AddField(
             model_name='advanced',
             name='adv_sed_user',
-            field=models.CharField(choices=[('user', 'User'), ('master', 'Master')], default='user', help_text='User passed to camcontrol security -U for unlocking SEDs', max_length=120, verbose_name='camcontrol security user'),
+            field=models.CharField(choices=[('user', 'User'), ('main', 'Main')], default='user', help_text='User passed to camcontrol security -U for unlocking SEDs', max_length=120, verbose_name='camcontrol security user'),
         ),
         migrations.RunPython(add_adv_sed_user),
     ]

--- a/freenasUI/system/migrations/0017_auto_20180219_1615.py
+++ b/freenasUI/system/migrations/0017_auto_20180219_1615.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
         AddField(
             model_name='advanced',
             name='adv_sed_user',
-            field=models.CharField(choices=[('user', 'User'), ('master', 'Master')], default='user', help_text='User passed to camcontrol security -U for unlocking SEDs', max_length=120, verbose_name='camcontrol security user'),
+            field=models.CharField(choices=[('user', 'User'), ('main', 'Main')], default='user', help_text='User passed to camcontrol security -U for unlocking SEDs', max_length=120, verbose_name='camcontrol security user'),
         ),
         migrations.RunPython(add_adv_sed_user),
     ]


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.